### PR TITLE
fix urls for hrefs in KMLs

### DIFF
--- a/acTrack2kml/Config.cc
+++ b/acTrack2kml/Config.cc
@@ -15,12 +15,24 @@ using std::string;
 // Output directories for .xml & .kml files.  Ground.
 static const string grnd_flightDataDir = "/net/www/docs/flight_data";
 static const string grnd_flightDataURL =
-  "http://www.eol.ucar.edu/flight_data";
+  // use simple urlpath to serve images from same host as the kml is served from,
+  // mediates against unannounced and flaky host/cname changes,
+  // allows catalog-maps to serve its own images
+  "/flight_data";
+
+  // OLDER: "http://www.eol.ucar.edu/flight_data";
+  // OLD: "https://www.eol.ucar.edu/flight_data";
+  // NO, NOT SUPPORTED, WILL DISAPPEAR: "https://archive.eol.ucar.edu/flight_data";
+  // NEW: "https://field.eol.ucar.edu/flight_data";
+  // NO, DON'T BE FOOLED: "https://flight.eol.ucar.edu/flight_data";
 
 // Output directories for .xml & .kml files.  Onboard.
 static const string onboard_flightDataDir = "/var/www/html/flight_data";
 static const string onboard_flightDataURL =
-  "http://acserver.raf.ucar.edu/flight_data";
+  // use simple urlpath to serve images from same host as the kml is served from,
+  // allows viewing via wired network hostnames like hyper.raf-guest.ucar.edu
+  "/flight_data";
+  // CANONICAL: "http://acserver.raf.ucar.edu/flight_data";
 
 
 string

--- a/avaps2kml/drop2kml.c
+++ b/avaps2kml/drop2kml.c
@@ -8,9 +8,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-static char *ground = "www.eol.ucar.edu";
-static char *onboard = "acserver.raf.ucar.edu";
-static char *webHost = 0;
+// 2023 canonical url prefixes are shown as comments,
+// but we prefer just the urlpath to allow serving
+// from other hosts like catalog.eol
+static char *ground = ""; // "https://field.eol.ucar.edu";
+static char *onboard = ""; // "http://acserver.raf.ucar.edu";
+static char *webPrefix = 0;
 
 void outputKML(float lat, float lon, float wd, float ws)
 {
@@ -46,7 +49,7 @@ void outputKML(float lat, float lon, float wd, float ws)
   printf("        <scale>3</scale>\n");
 //  printf("        <heading>0</heading>\n");
   printf("        <Icon>\n");
-  printf("          <href>http://%s/flight_data/display/windbarbs/%03d/wb_%03d_%03d.png</href>\n", webHost, iws, iws, (int)wd);
+  printf("          <href>%s/flight_data/display/windbarbs/%03d/wb_%03d_%03d.png</href>\n", webPrefix, iws, iws, (int)wd);
   printf("        </Icon>\n");
 //  printf("        <gx:headingMode>worldNorth</gx:headingMode>\n");
   printf("      </IconStyle>\n");
@@ -67,9 +70,9 @@ int main(int argc, char *argv[])
 
   gethostname(buffer, 1000);
   if (strncmp(buffer, "acserver", 8) == 0)
-    webHost = onboard;
+    webPrefix = onboard;
   else
-    webHost = ground;
+    webPrefix = ground;
 
   if (argc > 1)
     ps_cutoff = atof(argv[1]);

--- a/hdob2kml/hdob2kml.cpp
+++ b/hdob2kml/hdob2kml.cpp
@@ -84,7 +84,7 @@ void WriteGoogleEarthKMZ(std::string & file)
         "  <IconStyle>\n" <<
         "   <scale>0.5</scale>\n" <<
         "   <Icon>\n" <<
-        "    <href>http://www.eol.ucar.edu/flight_data/images/red.png</href>\n" <<
+        "    <href>https://field.eol.ucar.edu/flight_data/images/red.png</href>\n" <<
         "   </Icon>\n" <<
         "  </IconStyle>\n" <<
         " </Style>\n" <<
@@ -92,7 +92,7 @@ void WriteGoogleEarthKMZ(std::string & file)
         "  <IconStyle>\n" <<
         "   <scale>0.5</scale>\n" <<
         "   <Icon>\n" <<
-        "    <href>http://www.eol.ucar.edu/flight_data/images/white.png</href>\n" <<
+        "    <href>https://field.eol.ucar.edu/flight_data/images/white.png</href>\n" <<
         "   </Icon>\n" <<
         "  </IconStyle>\n" <<
         " </Style>\n" <<


### PR DESCRIPTION


````
switch to simple urlpaths for image links

update hdob2kml hrefs to current canonical absolute url

- allows serving from multiple hostnames:
  * catalog.eol.ucar.edu
  * hyper.raf-guest.ucar.edu
  * hercules.raf-guest.ucar.edu

- post-processing workflows for acTrack2kml will need to add:

    -u https://field.eol.ucar.edu/flight_data
````

Not sure about:
  * hdob, avaps
  * excessive comments about the urls

ping @topher800 